### PR TITLE
[react-image-gallery] getCurrentIndex() returns number not void

### DIFF
--- a/types/react-image-gallery/index.d.ts
+++ b/types/react-image-gallery/index.d.ts
@@ -79,7 +79,7 @@ declare class ReactImageGallery extends React.Component<ReactImageGalleryProps> 
     fullScreen: () => void;
     exitFullScreen: () => void;
     slideToIndex: (index: number) => void;
-    getCurrentIndex: () => void;
+    getCurrentIndex: () => number;
 }
 
 export default ReactImageGallery;

--- a/types/react-image-gallery/react-image-gallery-tests.tsx
+++ b/types/react-image-gallery/react-image-gallery-tests.tsx
@@ -2,6 +2,14 @@ import * as React from 'react';
 import ReactImageGallery, { ReactImageGalleryItem, ReactImageGalleryProps } from 'react-image-gallery';
 
 class ImageGallery extends React.Component {
+    private gallery: ReactImageGallery | null;
+
+    componentDidMount() {
+        if (this.gallery) {
+            const message = `Showing ${this.gallery.getCurrentIndex() + 1}. image the gallery.`;
+        }
+    }
+
     render() {
         const galleryItem: ReactImageGalleryItem = {
             original: 'http://localhost/logo.jpg',
@@ -14,6 +22,6 @@ class ImageGallery extends React.Component {
             showFullscreenButton: false
         };
 
-        return <ReactImageGallery {...props} />;
+        return <ReactImageGallery ref={(r) => this.gallery = r} {...props} />;
     }
 }


### PR DESCRIPTION
Based on source code: https://github.com/xiaolin/react-image-gallery/blob/master/src/ImageGallery.jsx#L379
`getCurrentIndex()` returns number.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/xiaolin/react-image-gallery/blob/master/src/ImageGallery.jsx#L379
